### PR TITLE
Feature/gnip faker verbosity configuration

### DIFF
--- a/gnip-faker/README.md
+++ b/gnip-faker/README.md
@@ -1,10 +1,10 @@
 # Gnip Faker
 
-Fakes the Gnip streaming server.
+Mocks a Gnip streaming server.
 
 ## Operation
 
-1. Reads the data file into memory (make sure it's not too big) and splits it into lines.
+1. Reads the data file into memory (make sure it's not too large) and splits it into lines.
 2. Listens for connections.
 3. Sends one line at a time from the file.
 4. Waits for a random delay between mindelay and maxdelay (milliseconds).
@@ -12,4 +12,4 @@ Fakes the Gnip streaming server.
 
 ## Usage
 
-./server.js [port=5001] [datafile=data/raw.json] [mindelay=4] [maxdelay=500]
+./server.js [port=5001] [datafile=data/raw.json] [mindelay=4] [maxdelay=500] [verbose=false]

--- a/gnip-faker/server.js
+++ b/gnip-faker/server.js
@@ -6,6 +6,7 @@ var fs = require('fs')
 	, data_filename = process.argv[3] || 'data/raw.json'
 	, min_delay_ms = process.argv[4] || 4
 	, max_delay_ms = process.argv[5] || 500
+	, verbose = process.argv[6] || false
 
 var data = fs.readFileSync(data_filename).toString().split("\n");
 
@@ -101,7 +102,9 @@ var sendNextLine = function(res, line_number) {
 		line_number = 0
 	}
 	res.write(data[line_number] + "\n")
-	console.log(data[line_number])
+	if (verbose) {
+		console.log(data[line_number])
+	}
 	setTimeout(function() {
 		sendNextLine(res, line_number + 1)
 	}, Math.floor(Math.random() * (max_delay_ms - min_delay_ms) + min_delay_ms))


### PR DESCRIPTION
Switch gnip-faker to be silent in console when serving interactions by default.
Provides ability to change this behaviour via parameter.

Should increase performance again, as stdout writes are blocking in Node 0.6+