### PR TITLE
historics_reader: added basic-Auth for GNIP pulls- fixed file path creation for downloa…

### DIFF
--- a/chef/cookbooks/historics-reader/recipes/default.rb
+++ b/chef/cookbooks/historics-reader/recipes/default.rb
@@ -64,5 +64,5 @@ cron_d 'historics-reader-cron' do
           '/usr/lib/datasift/historics-reader/*" '\
           'com.datasift.connector.HistoricsReader '\
           '/etc/datasift/historics-reader/reader.json'
-  user    'historicsreader'
+  user    'historicsapi'
 end

--- a/chef/cookbooks/historics-reader/templates/default/reader.json.erb
+++ b/chef/cookbooks/historics-reader/templates/default/reader.json.erb
@@ -5,7 +5,9 @@
   "gnip": {
     "base_url": "https://historical.gnip.com",
     "port": 443,
-    "account_name": "YOUR_ACCOUNT_NAME"
+    "account_name": "YOUR_ACCOUNT_NAME",
+	"user_name": "USER",
+	"password": "PASSWORD"
   },
   "kafka": {
     "topic": "twitter",

--- a/historics-reader/src/main/java/com/datasift/connector/reader/config/GnipConfig.java
+++ b/historics-reader/src/main/java/com/datasift/connector/reader/config/GnipConfig.java
@@ -29,4 +29,19 @@ public class GnipConfig {
     @NotNull
     @JsonProperty("account_name")
     public String accountName;
+
+    /**
+     *
+     */
+    @NotNull
+    @JsonProperty("user_name")
+    public String userName;
+
+    /**
+     *
+     */
+    @NotNull
+    @JsonProperty("password")
+    public String password;
+
 }


### PR DESCRIPTION
Fixed a few issues with the Historics_reader:
Added Basic Auth for http access to GNIP job status and pulling output files. 
fixed crontab defs for sqlite write access (changed user to historicapi)
fixed exception when GNIP job status JSON does not contain the 'suspectMinutesUrl' field.  

Yvon