### PR TITLE
Fix: Use latest nginx cookbook. Fix Vagrantfile nodes_path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision :chef_zero do |chef|
     #chef.cookbooks_path = ["chef/cookbooks"]
     chef.roles_path = "chef/roles"
+    chef.nodes_path = "chef/nodes"
     chef.data_bags_path = "chef/data_bags"
     chef.provisioning_path = "/tmp/vagrant-chef"
 

--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -20,3 +20,4 @@ cookbook 'influxdb',
          ref: '232e2afd4afb29b6eecb3369de84f1674272cd59'
 cookbook 'cron', '~> 1.6.1'
 cookbook 'nodejs', '~> 2.4.0'
+cookbook 'nginx', '~> 2.7.6'


### PR DESCRIPTION
Something was pulling in an old version of the nginx cookbook. Adding
2.7.6 to our Berksfile fixed the issue.

Add `chef.nodes_path` to `Vagrantfile` so that Vagrant knows where to
store node information