### PR TITLE
swap to GNIP 2.0 activitystreams, contd.

### DIFF
--- a/gnip-reader/pom.xml
+++ b/gnip-reader/pom.xml
@@ -16,9 +16,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.twitter</groupId>
+            <groupId>com.github.jimmoffitt.hbc</groupId>
             <artifactId>hbc-core</artifactId>
-            <version>2.2.0</version>
+            <version>master-hbc-2.2.0-g4e7cca7-31</version>
         </dependency>
     </dependencies>
     <build>

--- a/gnip-reader/src/main/java/com/datasift/connector/GnipReader.java
+++ b/gnip-reader/src/main/java/com/datasift/connector/GnipReader.java
@@ -4,7 +4,7 @@ import com.datasift.connector.reader.config.Config;
 import com.datasift.connector.reader.config.GnipReaderConfig;
 import com.datasift.connector.reader.config.GnipConfig;
 import com.twitter.hbc.core.Client;
-import com.twitter.hbc.core.endpoint.RealTimeEnterpriseStreamingEndpoint;
+import com.twitter.hbc.core.endpoint.RealTimeEnterpriseStreamingEndpoint_v2;
 import com.twitter.hbc.core.processor.LineStringProcessor;
 import com.twitter.hbc.httpclient.auth.BasicAuth;
 import org.slf4j.Logger;
@@ -68,8 +68,8 @@ public class GnipReader extends HosebirdReader {
 
         GnipConfig config = ((GnipReaderConfig) readerConfig).gnip;
 
-        RealTimeEnterpriseStreamingEndpoint endpoint =
-                new RealTimeEnterpriseStreamingEndpoint(
+        RealTimeEnterpriseStreamingEndpoint_v2 endpoint =
+                new RealTimeEnterpriseStreamingEndpoint_v2(
                         config.account,
                         config.product,
                         config.label);

--- a/gnip-reader/src/main/java/com/datasift/connector/reader/config/GnipConfig.java
+++ b/gnip-reader/src/main/java/com/datasift/connector/reader/config/GnipConfig.java
@@ -44,5 +44,5 @@ public class GnipConfig {
      * The endpoint of the Gnip stream.
      */
     @NotNull
-    public String host = Constants.ENTERPRISE_STREAM_HOST;
+    public String host = Constants.ENTERPRISE_STREAM_HOST_v2;
 }

--- a/gnip-reader/src/test/java/com/datasift/connector/TestGnipConfig.java
+++ b/gnip-reader/src/test/java/com/datasift/connector/TestGnipConfig.java
@@ -10,6 +10,6 @@ public class TestGnipConfig {
     @Test
     public void should_set_defaults_on_construction() {
         GnipConfig tc = new GnipConfig();
-        assertEquals(Constants.ENTERPRISE_STREAM_HOST, tc.host);
+        assertEquals(Constants.ENTERPRISE_STREAM_HOST_v2, tc.host);
     }
 }

--- a/gnip-reader/src/test/java/com/datasift/connector/TestGnipReader.java
+++ b/gnip-reader/src/test/java/com/datasift/connector/TestGnipReader.java
@@ -63,7 +63,7 @@ public class TestGnipReader {
         this.client = mock(BasicClient.class);
         this.cb = mock(ClientBuilder.class);
         when(cb.name("Gnip Reader")).thenReturn(cb);
-        when(cb.hosts(Constants.ENTERPRISE_STREAM_HOST)).thenReturn(cb);
+        when(cb.hosts(Constants.ENTERPRISE_STREAM_HOST_v2)).thenReturn(cb);
         when(cb.endpoint(any(StreamingEndpoint.class))).thenReturn(cb);
         when(cb.authentication(any(Authentication.class))).thenReturn(cb);
         when(cb.processor(any(HosebirdMessageProcessor.class))).thenReturn(cb);
@@ -146,11 +146,11 @@ public class TestGnipReader {
         LinkedBlockingQueue<String> lbq = new LinkedBlockingQueue<>(10);
         tr.getHosebirdClient(lbq, config);
         verify(cb).name("Gnip Reader");
-        verify(cb).hosts(Constants.ENTERPRISE_STREAM_HOST);
+        verify(cb).hosts(Constants.ENTERPRISE_STREAM_HOST_v2);
 
         ArgumentCaptor<StreamingEndpoint> se = ArgumentCaptor.forClass(StreamingEndpoint.class);
         verify(cb).endpoint(se.capture());
-        assertEquals("/accounts/ACCOUNT/publishers/twitter/streams/PRODUCT/LABEL.json", se.getValue().getURI());
+        assertEquals("/stream/PRODUCT/accounts/ACCOUNT/publishers/twitter/LABEL.json", se.getValue().getURI());
 
         // Unfortunately there's not a good way of asserting that the Authentication and Processor have
         // been created with the correct parameters.

--- a/hosebird-reader/pom.xml
+++ b/hosebird-reader/pom.xml
@@ -11,9 +11,9 @@
     </parent>
     <dependencies>
         <dependency>
-            <groupId>com.twitter</groupId>
+            <groupId>com.github.jimmoffitt.hbc</groupId>
             <artifactId>hbc-core</artifactId>
-            <version>2.2.0</version>
+            <version>master-hbc-2.2.0-g4e7cca7-31</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
 
     <repositories>
         <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/twitterapi-reader/pom.xml
+++ b/twitterapi-reader/pom.xml
@@ -16,9 +16,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.twitter</groupId>
+            <groupId>com.github.jimmoffitt.hbc</groupId>
             <artifactId>hbc-core</artifactId>
-            <version>2.2.0</version>
+            <version>master-hbc-2.2.0-g4e7cca7-31</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
* use the GNIP fork of hosebird from jimmoffitt
* use https://jitpack.io/ since I can't find their fork published anywhere
* follow their migration guide to use the new URLs